### PR TITLE
BUILD: update veracode job condition and remove dependency

### DIFF
--- a/.github/workflows/fluxus-release-pipeline.yaml
+++ b/.github/workflows/fluxus-release-pipeline.yaml
@@ -355,11 +355,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - code_quality_checks
-      - check_release
     # IF (PR from dev/ to release/) OR (push into release/) OR (scheduled run)
-    # if: startsWith(github.head_ref, 'dev/') || startsWith(github.ref, 'refs/heads/release/') || github.event_name == 'schedule'
-    if: github.event_name == 'schedule'
-
+    if: startsWith(github.head_ref, 'dev/') || startsWith(github.ref, 'refs/heads/release/') || github.event_name == 'schedule'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Enabling Veracode's static scan requires three changes:
1. Setting Veracode API ID and API KEY in GitHub Secrets
2. Setting the job's condition (in GHA workflow) to run if (PR from dev/ to release/) OR (push into release/) OR (scheduled run)
3. Remove job's dependency on check_release which never runs on a schedule trigger contradicting veracode's.